### PR TITLE
Changed the i18n function to use the users locale instead of the default WP locale

### DIFF
--- a/disciple-tools-starter-plugin.php
+++ b/disciple-tools-starter-plugin.php
@@ -248,11 +248,21 @@ class DT_Starter_Plugin {
      * @return void
      */
     public function i18n() {
-        global $locale;
-        $locale = get_user_locale();
-        load_plugin_textdomain( 'dt_starter_plugin', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ). 'languages/' );
-    }
+        //Take from loadTextDomain() in /disciple-tools-theme/dt-core/libraries/plugin-update-checker/Puc/v4p5/UpdateChecker.php
+        $domain = 'dt_starter_plugin';
+        $locale = apply_filters(
+            'plugin_locale',
+            (is_admin() && function_exists('get_user_locale')) ? get_user_locale() : get_locale(),
+            $domain
+        );
 
+        $moFile = $domain . '-' . $locale . '.mo';
+        $path = realpath(dirname(__FILE__) . '/languages');
+
+        if ($path && file_exists($path)) {
+            load_textdomain($domain, $path . '/' . $moFile);
+        }
+    }
     /**
      * Magic method to output a string if trying to use the object as a string.
      *

--- a/disciple-tools-starter-plugin.php
+++ b/disciple-tools-starter-plugin.php
@@ -208,7 +208,7 @@ class DT_Starter_Plugin {
         }
 
         // Internationalize the text strings used.
-        add_action( 'plugins_loaded', array( $this, 'i18n' ), 2 );
+        add_action( 'init', array( $this, 'i18n' ), 2 );
     }
 
     /**
@@ -248,7 +248,9 @@ class DT_Starter_Plugin {
      * @return void
      */
     public function i18n() {
-        load_plugin_textdomain( 'dt_starter_plugin', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ). 'languages' );
+        global $locale;
+        $locale = get_user_locale();
+        load_plugin_textdomain( 'dt_starter_plugin', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ). 'languages/' );
     }
 
     /**


### PR DESCRIPTION
…ult Wordpress locale so that the translations are loaded if someone is using something other than the Wordpress Default language allowing you to have users in DT users in multiple languages.

Also changed the hook that is used to load the i18n function so that get_users_locale() is available.